### PR TITLE
Use GEMINI_API_KEY for AnalyzerPage

### DIFF
--- a/pages/AnalyzerPage.tsx
+++ b/pages/AnalyzerPage.tsx
@@ -13,7 +13,7 @@ import { EditIcon } from '../components/icons/EditIcon';
 import type { AnalysisResult as AnalysisResultType } from '../types';
 
 // --- Gemini AI Setup ---
-const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
 
 const analysisSchema = {
     type: Type.OBJECT,


### PR DESCRIPTION
## Summary
- load Gemini API key from `process.env.GEMINI_API_KEY` in analyzer page

## Testing
- `npm test` (fails: Missing script)
- `GEMINI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abfc2c83d88320b37ad27eb146abe7